### PR TITLE
1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 > [!TIP]
 > このアドオンは Godot Engine 及び Redot Engine に対応しています。
 >
-> * Godot Engine 4.3 ~
-> * Redot Engine 4.3 Beta 2 ~
+> * Godot Engine 4.4 ~
+> * Redot Engine 4.3 ~
 
 <br />
 

--- a/Test_BigInt.gd.uid
+++ b/Test_BigInt.gd.uid
@@ -1,0 +1,1 @@
+uid://b0vg7rmbd1v4t

--- a/Test_BigInt.tscn
+++ b/Test_BigInt.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://dfpp51itiuggs"]
 
-[ext_resource type="Script" path="res://Test_BigInt.gd" id="1_njdli"]
+[ext_resource type="Script" uid="uid://b0vg7rmbd1v4t" path="res://Test_BigInt.gd" id="1_njdli"]
 
 [node name="Test_BigInt" type="MarginContainer"]
 auto_translate_mode = 2

--- a/addons/xdut-bigint/BigInt.gd.uid
+++ b/addons/xdut-bigint/BigInt.gd.uid
@@ -1,0 +1,1 @@
+uid://bkc0xgxryfh30

--- a/addons/xdut-bigint/BigIntChineseFormatter.gd.uid
+++ b/addons/xdut-bigint/BigIntChineseFormatter.gd.uid
@@ -1,0 +1,1 @@
+uid://d1264vjvhwu0r

--- a/addons/xdut-bigint/BigIntFormatter.gd.uid
+++ b/addons/xdut-bigint/BigIntFormatter.gd.uid
@@ -1,0 +1,1 @@
+uid://bb4xmee88h6ih

--- a/addons/xdut-bigint/BigIntJapaneseFormatter.gd.uid
+++ b/addons/xdut-bigint/BigIntJapaneseFormatter.gd.uid
@@ -1,0 +1,1 @@
+uid://bro2dc8m0ocof

--- a/addons/xdut-bigint/BigIntLongFormFormatter.gd.uid
+++ b/addons/xdut-bigint/BigIntLongFormFormatter.gd.uid
@@ -1,0 +1,1 @@
+uid://b727md1q8tj2n

--- a/addons/xdut-bigint/BigIntSIFormatter.gd.uid
+++ b/addons/xdut-bigint/BigIntSIFormatter.gd.uid
@@ -1,0 +1,1 @@
+uid://bsmq11oqmst1k

--- a/addons/xdut-bigint/BigIntShortFormFormatter.gd.uid
+++ b/addons/xdut-bigint/BigIntShortFormFormatter.gd.uid
@@ -1,0 +1,1 @@
+uid://b4jg64x5el6w7

--- a/addons/xdut-bigint/BigIntTaiwaneseFormatter.gd.uid
+++ b/addons/xdut-bigint/BigIntTaiwaneseFormatter.gd.uid
@@ -1,0 +1,1 @@
+uid://dp8r4jf323bkh

--- a/addons/xdut-bigint/plugin.cfg
+++ b/addons/xdut-bigint/plugin.cfg
@@ -3,5 +3,5 @@
 name="XDUT Big Integer"
 description="巨大な符号なし整数を扱うためのアドオンです。"
 author="Ydi (@ydipeepo.bsky.social)"
-version="1.1.0"
+version="1.1.1"
 script="plugin.gd"

--- a/addons/xdut-bigint/plugin.gd.uid
+++ b/addons/xdut-bigint/plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://b7kfvlsfpvfqg

--- a/project.godot
+++ b/project.godot
@@ -14,7 +14,7 @@ config/name="XDUT Big Integer"
 config/description="巨大な符号なし整数を扱うためのアドオンです。"
 config/tags=PackedStringArray("xdut")
 run/main_scene="res://Test_BigInt.tscn"
-config/features=PackedStringArray("4.3", "GL Compatibility")
+config/features=PackedStringArray("4.4", "GL Compatibility")
 boot_splash/bg_color=Color(0, 0, 0, 1)
 boot_splash/show_image=false
 boot_splash/fullsize=false
@@ -31,6 +31,12 @@ window/vsync/vsync_mode=0
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/xdut-bigint/plugin.cfg")
+
+[file_customization]
+
+folder_colors={
+"res://addons/xdut-bigint/": "pink"
+}
 
 [filesystem]
 


### PR DESCRIPTION
* #3 Godot Engine 4.4 に対応

アドオン本体の修正を含まないため `./addons/xdut-bigint` 以下のみプロジェクトに追加している場合の対応は不要です。